### PR TITLE
Add automated paper compilation check

### DIFF
--- a/.github/workflows/paper-check.yml
+++ b/.github/workflows/paper-check.yml
@@ -1,0 +1,23 @@
+on: [push]
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper.pdf


### PR DESCRIPTION
This adds a workflow that will automatically check that the paper is compiling once it's added as a markdown file. Getting the paper compiling is an important part of submission and this will help.